### PR TITLE
[wabbit-amqp] surfaces CorrelationId and ReplyTo fields to the wabbit layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 go:
   - tip
-  - 1.8
+  - 1.9
 install:
   - go get -d -v ./...
   - go build

--- a/_examples/publisher/exchange.go
+++ b/_examples/publisher/exchange.go
@@ -79,7 +79,7 @@ func publish(uri string, queueName string, exchange string, exchangeType string,
 	}
 }
 
-func connect(uri string) (*amqp.Conn, error) {
+func connect(uri string) (wabbit.Conn, error) {
 	return amqp.Dial(uri)
 }
 

--- a/_examples/publisher/exchange.go
+++ b/_examples/publisher/exchange.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/NeowayLabs/wabbit"
 	"github.com/NeowayLabs/wabbit/amqp"
-	"log"
 )
 
 var (
@@ -110,8 +111,8 @@ func confirmOne(confirms <-chan wabbit.Confirmation) {
 	log.Printf("[-] Waiting for confirmation of one publishing")
 
 	if confirmed := <-confirms; confirmed.Ack() {
-		log.Printf("[√] Confirmed delivery with delivery tag: %d", confirmed.DeliveryTag)
+		log.Printf("[√] Confirmed delivery with delivery tag: %d", confirmed.DeliveryTag())
 	} else {
-		log.Printf("[x] Failed delivery of delivery tag: %d", confirmed.DeliveryTag)
+		log.Printf("[x] Failed delivery of delivery tag: %d", confirmed.DeliveryTag())
 	}
 }

--- a/_examples/worker_queue/worker_queue.go
+++ b/_examples/worker_queue/worker_queue.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
+	"log"
+
 	"github.com/NeowayLabs/wabbit"
 	"github.com/NeowayLabs/wabbit/amqp"
-	"log"
 )
 
 var (
@@ -69,7 +70,7 @@ func publish(uri string, queueName string, body string, reliable bool) {
 	}
 }
 
-func connect(uri string) (*amqp.Conn, error) {
+func connect(uri string) (wabbit.Conn, error) {
 	return amqp.Dial(uri)
 }
 
@@ -100,8 +101,8 @@ func confirmOne(confirms <-chan wabbit.Confirmation) {
 	log.Printf("[-] Waiting for confirmation of one publishing")
 
 	if confirmed := <-confirms; confirmed.Ack() {
-		log.Printf("[√] Confirmed delivery with delivery tag: %d", confirmed.DeliveryTag)
+		log.Printf("[√] Confirmed delivery with delivery tag: %d", confirmed.DeliveryTag())
 	} else {
-		log.Printf("[x] Failed delivery of delivery tag: %d", confirmed.DeliveryTag)
+		log.Printf("[x] Failed delivery of delivery tag: %d", confirmed.DeliveryTag())
 	}
 }

--- a/amqp.go
+++ b/amqp.go
@@ -60,7 +60,9 @@ type (
 		Headers() Option
 		DeliveryTag() uint64
 		ConsumerTag() string
+		CorrelationId() string
 		MessageId() string
+		ReplyTo() string
 	}
 
 	// Confirmation is an interface to confrimation messages

--- a/amqp/delivery.go
+++ b/amqp/delivery.go
@@ -17,6 +17,10 @@ func (d *Delivery) Headers() wabbit.Option {
 	return wabbit.Option(d.Delivery.Headers)
 }
 
+func (d *Delivery) CorrelationId() string {
+	return d.Delivery.CorrelationId
+}
+
 func (d *Delivery) DeliveryTag() uint64 {
 	return d.Delivery.DeliveryTag
 }
@@ -27,4 +31,8 @@ func (d *Delivery) ConsumerTag() string {
 
 func (d *Delivery) MessageId() string {
 	return d.Delivery.MessageId
+}
+
+func (d *Delivery) ReplyTo() string {
+	return d.Delivery.ReplyTo
 }

--- a/amqp/dial.go
+++ b/amqp/dial.go
@@ -18,7 +18,7 @@ type Conn struct {
 }
 
 // Dial to AMQP broker
-func Dial(uri string) (*Conn, error) {
+func Dial(uri string) (wabbit.Conn, error) {
 	conn := &Conn{}
 
 	// closure the uri for handle reconnects

--- a/amqptest/dial.go
+++ b/amqptest/dial.go
@@ -32,7 +32,7 @@ type Conn struct {
 
 // Dial mock the connection dialing to rabbitmq and
 // returns the established connection or error if something goes wrong
-func Dial(amqpuri string) (*Conn, error) {
+func Dial(amqpuri string) (wabbit.Conn, error) {
 	conn := &Conn{
 		amqpuri:    amqpuri,
 		errSpread:  utils.NewErrBroadcast(),

--- a/amqptest/server/channel.go
+++ b/amqptest/server/channel.go
@@ -97,10 +97,12 @@ func (ch *Channel) NotifyPublish(confirm chan wabbit.Confirmation) chan wabbit.C
 func (ch *Channel) Publish(exc, route string, msg []byte, opt wabbit.Option) error {
 	hdrs, _ := opt["headers"].(amqp.Table)
 	messageId, _ := opt["messageId"].(string)
+	correlationId, _ := opt["correlationId"].(string)
 	d := NewDelivery(ch,
 		msg,
 		atomic.AddUint64(&ch.deliveryTagCounter, 1),
 		messageId,
+		correlationId,
 		wabbit.Option(hdrs))
 
 	err := ch.VHost.Publish(exc, route, d, nil)
@@ -161,7 +163,7 @@ func (ch *Channel) Consume(queue, consumerName string, _ wabbit.Option) (<-chan 
 				// since we keep track of unacked messages for
 				// the channel, we need to rebind the delivery
 				// to the consumer channel.
-				d = NewDelivery(ch, d.Body(), d.DeliveryTag(), d.MessageId(), d.Headers())
+				d = NewDelivery(ch, d.Body(), d.DeliveryTag(), d.MessageId(), d.CorrelationId(), d.Headers())
 
 				ch.addUnacked(d, q)
 

--- a/amqptest/server/delivery.go
+++ b/amqptest/server/delivery.go
@@ -9,19 +9,22 @@ type (
 		headers       wabbit.Option
 		tag           uint64
 		consumerTag   string
+		correlationId string
 		originalRoute string
 		messageId     string
+		replyTo       string
 		channel       *Channel
 	}
 )
 
-func NewDelivery(ch *Channel, data []byte, tag uint64, messageId string, hdrs wabbit.Option) *Delivery {
+func NewDelivery(ch *Channel, data []byte, tag uint64, messageId, correlationId string, hdrs wabbit.Option) *Delivery {
 	return &Delivery{
-		data:      data,
-		headers:   hdrs,
-		channel:   ch,
-		tag:       tag,
-		messageId: messageId,
+		data:          data,
+		headers:       hdrs,
+		channel:       ch,
+		tag:           tag,
+		messageId:     messageId,
+		correlationId: correlationId,
 	}
 }
 
@@ -53,6 +56,14 @@ func (d *Delivery) ConsumerTag() string {
 	return d.consumerTag
 }
 
+func (d *Delivery) CorrelationId() string {
+	return d.correlationId
+}
+
 func (d *Delivery) MessageId() string {
 	return d.messageId
+}
+
+func (d *Delivery) ReplyTo() string {
+	return d.replyTo
 }

--- a/amqptest/server/vhost_test.go
+++ b/amqptest/server/vhost_test.go
@@ -117,7 +117,7 @@ func TestQueueBind(t *testing.T) {
 		return
 	}
 
-	err = nwExchange.route("process.data", NewDelivery(&Channel{}, []byte{}, 1, "", wabbit.Option{}))
+	err = nwExchange.route("process.data", NewDelivery(&Channel{}, []byte{}, 1, "", "", wabbit.Option{}))
 
 	if err != nil {
 		t.Error(err)
@@ -154,7 +154,7 @@ func TestBasicPublish(t *testing.T) {
 		return
 	}
 
-	err = vh.Publish("neoway", "process.data", NewDelivery(&Channel{}, []byte("teste"), 1, "", wabbit.Option{}), nil)
+	err = vh.Publish("neoway", "process.data", NewDelivery(&Channel{}, []byte("teste"), 1, "", "", wabbit.Option{}), nil)
 
 	if err != nil {
 		t.Error(err)

--- a/utils/opt.go
+++ b/utils/opt.go
@@ -14,6 +14,7 @@ var (
 		"headers",
 		"contentType",
 		"contentEncoding",
+		"correlationId",
 		"deliveryMode",
 		"priority",
 		"messageId",
@@ -38,10 +39,11 @@ func ConvertOpt(opt wabbit.Option) (amqp.Publishing, error) {
 		deliveryMode    = amqp.Transient
 		priority        = uint8(0)
 		messageId       = ""
+		correlationId   = ""
 	)
 
 	if wrongOpt, ok := checkOptions(opt); !ok {
-		return amqp.Publishing{}, fmt.Errorf("Wring option '%s'. Check the docs.", wrongOpt)
+		return amqp.Publishing{}, fmt.Errorf("Wrong option '%s'. Check the docs.", wrongOpt)
 	}
 
 	if opt != nil {
@@ -55,6 +57,10 @@ func ConvertOpt(opt wabbit.Option) (amqp.Publishing, error) {
 
 		if c, ok := opt["contentEncoding"].(string); ok {
 			contentEncoding = c
+		}
+
+		if c, ok := opt["correlationId"].(string); ok {
+			correlationId = c
 		}
 
 		if d, ok := opt["deliveryMode"].(uint8); ok {
@@ -74,6 +80,7 @@ func ConvertOpt(opt wabbit.Option) (amqp.Publishing, error) {
 		Headers:         headers,
 		ContentType:     contentType,
 		ContentEncoding: contentEncoding,
+		CorrelationId:   correlationId,
 		DeliveryMode:    deliveryMode, // 1=non-persistent, 2=persistent
 		Priority:        priority,     // 0-9
 		MessageId:       messageId,

--- a/utils/opt_test.go
+++ b/utils/opt_test.go
@@ -38,6 +38,10 @@ func TestConvertOptDefaults(t *testing.T) {
 	if len(opt.Headers) != 0 {
 		t.Errorf("Invalid value for headers: %v", opt.Headers)
 	}
+
+	if opt.CorrelationId != "" {
+		t.Errorf("Invalid correlation ID: %s\n", opt.CorrelationId)
+	}
 }
 
 func TestConvertOpt(t *testing.T) {
@@ -96,6 +100,19 @@ func TestConvertOpt(t *testing.T) {
 
 	if opt.MessageId != "12345" {
 		t.Errorf("Invalid value for messageId: %s", opt.MessageId)
+	}
+
+	opt, err = ConvertOpt(wabbit.Option{
+		"correlationId": "0123-4414",
+	})
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if opt.CorrelationId != "0123-4414" {
+		t.Errorf("Invalid value for correlationId: %s", opt.CorrelationId)
 	}
 
 	// setting invalid value


### PR DESCRIPTION

[wabbit-amqp] surfaces CorrelationId and ReplyTo fields to the wabbit layer

**Why**
These fields are used for RPC over RabbitMQ

**What**
Adds getters for CorrelationId and ReplyTo fields of the amqp.Delivery struct
Allows correlationId to be a valid wabbit.Option for published RPC messages