### PR TITLE
[amqptest] VHost.QueueNames() helper method to allow tests that use a…

### DIFF
--- a/amqptest/server/vhost.go
+++ b/amqptest/server/vhost.go
@@ -177,3 +177,14 @@ func (v *VHost) Publish(exc, route string, d *Delivery, _ wabbit.Option) error {
 
 	return nil
 }
+
+// QueueNames returns a list of declared queues in this AMQP fake virtual host
+func (v *VHost) QueueNames() []string {
+	queueNames := make([]string, len(v.queues))
+	i := 0
+	for key := range v.queues {
+		queueNames[i] = key
+		i++
+	}
+	return queueNames
+}

--- a/amqptest/server/vhost_test.go
+++ b/amqptest/server/vhost_test.go
@@ -175,3 +175,35 @@ func TestBasicPublish(t *testing.T) {
 		return
 	}
 }
+
+func TestQueueNames(t *testing.T) {
+	vh := NewVHost("/")
+
+	queueNames := vh.QueueNames()
+	if len(queueNames) != 0 {
+		t.Errorf("QueueNames was not empty, but should be")
+	}
+
+	_, err := vh.QueueDeclare("test-queue-0", nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	queueNames = vh.QueueNames()
+	if len(queueNames) != 1 ||
+		queueNames[0] != "test-queue-0" {
+		t.Errorf("QueueNames did not return the right queue names")
+	}
+
+	_, err = vh.QueueDeclare("test-queue-1", nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	queueNames = vh.QueueNames()
+	if len(queueNames) != 2 ||
+		queueNames[0] != "test-queue-0" ||
+		queueNames[1] != "test-queue-1" {
+		t.Errorf("QueueNames did not return the right queue names")
+	}
+}


### PR DESCRIPTION
…mqptest to inspect declared queues

What:

This adds a helper to inspect the declared queues within a fake virtual
host.

Why:

To allow tests that use amqptest to inspect the declared queues and
ensure that they either declared or didn't declare queues.